### PR TITLE
add help brief, with extra visuals

### DIFF
--- a/cmd/kubehelp/main.go
+++ b/cmd/kubehelp/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -23,20 +24,25 @@ func main() {
 
 	c := client.NewClient(apiKey)
 
-	commands, err := c.Prompt(strings.Join(os.Args[1:], " "))
+	data, err := c.Prompt(strings.Join(os.Args[1:], " "))
 	if err != nil {
 		log.Fatalf("Failed to prompt: %v", err)
 	}
+	commands := data.Commands
 	if len(commands) == 0 {
 		exit("Couldn't figure out what to execute...")
 	}
 
+	fmt.Println("Commands:")
 	for _, command := range commands {
-		fmt.Println(command)
+		fmt.Println(">>> ", command)
 	}
+
+	fmt.Printf("\nExplanation:\n%s\n\n", data.Explanation)
 	prompt := promptui.Prompt{
-		Label:     "Execute",
+		Label:     "Execute commands?",
 		IsConfirm: true,
+		Validate:  validate,
 	}
 	result, err := prompt.Run()
 	if err != nil {
@@ -53,6 +59,17 @@ func main() {
 			log.Fatalf("Failed to run command: %v", err)
 		}
 	}
+}
+
+func validate(input string) error {
+	input = strings.ToLower(input)
+	if input == "" {
+		return errors.New("Input is required. Please enter 'y' or 'n'.")
+	}
+	if input != "y" && input != "n" {
+		return errors.New("Invalid input. Please enter 'y' or 'n'.")
+	}
+	return nil
 }
 
 func exit(msg string) {

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require github.com/manifoldco/promptui v0.9.0
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,6 @@ github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYt
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b h1:MQE+LT/ABUuuvEZ+YQAMSXindAdUh7slEmAkup74op4=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
loved the repo.
I just want to see a nice brief of whats going on and learn from it.

- updated prompt to return a yaml response so I could parse it easilly
- llm is annoying so I needed to clean the yaml a bit from time to time from "```yaml" or "```"
- displayed the commands a bit more bolded
- and added verify for approvals, because I always type enter many types to space the cli

<img width="714" alt="Screenshot 2024-03-23 at 10 04 28" src="https://github.com/rakyll/kubehelp/assets/3749973/2a5f108a-312f-415f-bd8c-c0d05a377076">
<img width="1280" alt="Screenshot 2024-03-23 at 10 04 54" src="https://github.com/rakyll/kubehelp/assets/3749973/edc076b3-9198-4504-bf93-5f986f0be172">

